### PR TITLE
browser: Bump version of the Lightstep exporter

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -17,7 +17,7 @@
     "@opentelemetry/plugin-xml-http-request": "^0.5.2",
     "@opentelemetry/tracing": "^0.5.2",
     "@opentelemetry/web": "^0.5.2",
-    "lightstep-opentelemetry-exporter": "^0.1.0"
+    "lightstep-opentelemetry-exporter": "^0.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
The instructions are for 0.2, and we need version 0.2.1 to get an
important bug fix.