### PR TITLE
Clarify headers for local satellites

### DIFF
--- a/example-collector-config.yaml
+++ b/example-collector-config.yaml
@@ -14,11 +14,14 @@ exporters:
     # otlp:
     #   endpoint: satellite:8360
     #   insecure: true
+    #   headers:
+    #     "lightstep-access-token": "<ACCESS TOKEN>"
 
     # configuring otlp to public satellites
     otlp:
       endpoint: ingest.lightstep.com:443
-      headers: {"lightstep-access-token":"<ACCESS TOKEN>"}
+      headers: 
+        "lightstep-access-token": "<ACCESS TOKEN>"
     
       # configure collector to send data to jaeger
     # jaeger:


### PR DESCRIPTION
Clarify that the access token is required for local satellites. Format headers to match the (test config)[https://github.com/open-telemetry/opentelemetry-collector/blob/master/exporter/otlpexporter/testdata/config.yaml]