### PR TITLE
bump collector docker image to v0.9.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -439,7 +439,7 @@ services:
         stop_grace_period: 1s
     otel-collector:
         container_name: otel-collector
-        image: otel/opentelemetry-collector:0.6.1
+        image: otel/opentelemetry-collector:0.9.0
         command: ["--config=/conf/collector-config.yaml", "--log-level=DEBUG"]
         networks:
             - demo


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.9.0 released 2 days ago

i ran `docker-compose up` with this PR changes and stuff still worked; at least from inspecting the `docker logs py-collector-client -f` output.