### PR TITLE
Use B3 propagation for ASP.NET Core instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dependency-reduced-pom.xml
 *.jar
 .swp
 collector/collector-config.yaml
+
+dotnet/server/aspnetapp/bin
+dotnet/server/aspnetapp/obj

--- a/dotnet/server/Dockerfile
+++ b/dotnet/server/Dockerfile
@@ -10,8 +10,6 @@ RUN dotnet restore -r linux-x64
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
-RUN dotnet add package OpenTelemetry.Exporter.Console -v 0.4.0-beta.2
-RUN dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol -v 0.4.0-beta.2
 RUN dotnet restore -r linux-x64
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained false --no-restore
 

--- a/dotnet/server/aspnetapp/Pages/Index.cshtml.cs
+++ b/dotnet/server/aspnetapp/Pages/Index.cshtml.cs
@@ -26,20 +26,6 @@ namespace aspnetapp.Pages
 
         public void OnGet()
         {
-
-            using var otel = Sdk.CreateTracerProvider(b => b
-                .AddActivitySource("MyCompany.MyProduct.MyLibrary")
-                .UseOtlpExporter(opt =>
-                {
-                    opt.Endpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_SPAN_ENDPOINT");
-                    opt.Headers = new Metadata
-                    {
-                        { "lightstep-access-token", Environment.GetEnvironmentVariable("LS_ACCESS_TOKEN")}
-                    };
-                    opt.Credentials = new SslCredentials();
-                })
-                .SetResource(Resources.CreateServiceResource(Environment.GetEnvironmentVariable("LS_SERVICE_NAME"), serviceVersion: Environment.GetEnvironmentVariable("LS_SERVICE_VERSION"))));
-
             using (var activity = activitySource.StartActivity("SayHello"))
             {
                 activity?.AddTag("bar", "Hello, World!");

--- a/dotnet/server/aspnetapp/Startup.cs
+++ b/dotnet/server/aspnetapp/Startup.cs
@@ -8,6 +8,10 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
+using Grpc.Core;
 
 namespace aspnetapp
 {
@@ -24,6 +28,20 @@ namespace aspnetapp
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
+            services.AddOpenTelemetryTracing((builder) => builder
+                .AddAspNetCoreInstrumentation(opt => {
+                    opt.Propagator = new OpenTelemetry.Context.Propagation.B3Propagator();
+                })
+                .AddOtlpExporter(opt => {
+                    opt.Endpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_SPAN_ENDPOINT");
+                    opt.Headers = new Metadata
+                    {
+                        { "lightstep-access-token", Environment.GetEnvironmentVariable("LS_ACCESS_TOKEN")}
+                    };
+                    opt.Credentials = new SslCredentials();
+                })
+                .SetResource(Resources.CreateServiceResource(Environment.GetEnvironmentVariable("LS_SERVICE_NAME"), serviceVersion: Environment.GetEnvironmentVariable("LS_SERVICE_VERSION")))
+            );
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/dotnet/server/aspnetapp/aspnetapp.csproj
+++ b/dotnet/server/aspnetapp/aspnetapp.csproj
@@ -4,5 +4,10 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>57393389627611478466</UserSecretsId>
   </PropertyGroup>
-
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="0.6.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="0.6.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="0.6.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="0.6.0-beta.1" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Refactor OTel init to be more idiomatic
- Use B3 propagation
- Update to 0.6b OTel .NET
- Move dependencies into csproj