### PR TITLE
Add example for the AWS OpenTelemetry Distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git clone https://github.com/lightstep/opentelemetry-examples && cd opentelemetr
 # and update the access token
 cp example.env .env
 sed -i '' 's/<ACCESS TOKEN>/YOUR TOKEN HERE/' .env
+# if using the AWS OpenTelemetry Distro, use `example-aws-collector-config.yaml`
 cp example-collector-config.yaml ./collector/collector-config.yaml
 sed -i '' 's/<ACCESS TOKEN>/YOUR TOKEN HERE/' ./collector/collector-config.yaml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -578,6 +578,17 @@ services:
         ports:
             - "0.0.0.0:8889:8889"   # Prometheus exporter metrics
             - "0.0.0.0:55680:55680" # OTLP receiver
+    # aws-otel-collector:
+    #     image: amazon/aws-otel-collector:latest
+    #     networks:
+    #         - demo
+    #     command: ["--config=/etc/otel-agent-config.yaml", "--log-level=DEBUG"]
+    #     ports:
+    #         - "0.0.0.0:55680:55680" # OTLP receiver
+    #     volumes:
+    #         - ./collector/collector-config.yaml:/etc/otel-agent-config.yaml
+    #     env_file:
+    #         - .env
     # jaeger:
     #     container_name: jaeger
     #     image: jaegertracing/all-in-one:latest

--- a/example-aws-collector-config.yaml
+++ b/example-aws-collector-config.yaml
@@ -1,0 +1,37 @@
+# Example config for the AWS OpenTelemetry Distro
+# This sends data to Lightstep, AWS EMF, and X-Ray
+# https://github.com/aws-observability/aws-otel-collector
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:55680
+
+processors:
+  batch/traces:
+    timeout: 1s
+    send_batch_size: 50
+  batch/metrics:
+    timeout: 60s
+
+exporters:
+  awsxray:
+  awsemf:
+  logging:
+    loglevel: debug
+  otlp:
+    endpoint: ingest.lightstep.com:443
+    headers:
+      "lightstep-access-token": "<ACCESS TOKEN>"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch/traces]
+      exporters: [awsxray, otlp, logging]
+    metrics:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [awsemf, otlp]

--- a/example.env
+++ b/example.env
@@ -40,3 +40,8 @@ INTEGRATION_CONFIG_FILE=/config/integration.yml
 ORG_NAME=<ORG_NAME>
 PROJECT_NAME=<PROJECT_NAME>
 API_KEY=<API_KEY>
+
+# Configuration for AWS OTel Collector
+AWS_ACCESS_KEY_ID=<to_be_added>
+AWS_SECRET_ACCESS_KEY=<to_be_added>
+AWS_REGION=<to_be_added>


### PR DESCRIPTION
Adds example collector config + docker service (commented out) for the [AWS OpenTelemetry distribution](https://github.com/aws-observability/aws-otel-collector).