### PR TITLE
Update py otel

### DIFF
--- a/python/launcher/Dockerfile.client
+++ b/python/launcher/Dockerfile.client
@@ -5,7 +5,7 @@ WORKDIR /app
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-RUN opentelemetry-bootstrap -a install
+# RUN opentelemetry-bootstrap -a install
 
 ADD client.py /app/client.py
 CMD ["opentelemetry-instrument", "/app/client.py"]

--- a/python/launcher/Dockerfile.server
+++ b/python/launcher/Dockerfile.server
@@ -5,7 +5,7 @@ WORKDIR /app
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-RUN opentelemetry-bootstrap -a install
+# RUN opentelemetry-bootstrap -a install
 
 ADD server.py /app/server.py
 CMD ["opentelemetry-instrument", "/app/server.py"]

--- a/python/launcher/requirements.txt
+++ b/python/launcher/requirements.txt
@@ -5,3 +5,5 @@ redis
 requests
 sqlalchemy
 opentelemetry-launcher==0.17b0
+opentelemetry-instrumentation-requests==0.17b0
+opentelemetry-instrumentation-flask==0.17b0

--- a/python/opentelemetry/requirements.txt
+++ b/python/opentelemetry/requirements.txt
@@ -4,6 +4,6 @@ pymongo
 redis
 requests
 sqlalchemy
-opentelemetry-instrumentation==0.17b0
-opentelemetry-exporter-otlp==0.17b0
-opentelemetry-propagator-b3==0.17b0
+opentelemetry-instrumentation==0.18b0
+opentelemetry-exporter-otlp==1.0.0rc1
+opentelemetry-propagator-b3==1.0.0rc1

--- a/python/opentracing/Dockerfile.client
+++ b/python/opentracing/Dockerfile.client
@@ -5,7 +5,7 @@ WORKDIR /app
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-RUN opentelemetry-bootstrap -a install
+# RUN opentelemetry-bootstrap -a install
 
 ADD client.py /app/client.py
 CMD ["opentelemetry-instrument", "python", "/app/client.py"]

--- a/python/opentracing/Dockerfile.server
+++ b/python/opentracing/Dockerfile.server
@@ -5,7 +5,7 @@ WORKDIR /app
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-RUN opentelemetry-bootstrap -a install
+# RUN opentelemetry-bootstrap -a install
 
 ADD server.py /app/server.py
 CMD ["opentelemetry-instrument", "python", "/app/server.py"]

--- a/python/opentracing/requirements.txt
+++ b/python/opentracing/requirements.txt
@@ -5,4 +5,6 @@ redis
 requests
 sqlalchemy
 opentelemetry-launcher==0.17b0
-opentelemetry-opentracing-shim
+opentelemetry-opentracing-shim==0.17b0
+opentelemetry-instrumentation-requests==0.17b0
+opentelemetry-instrumentation-flask==0.17b0


### PR DESCRIPTION
Updating otel to use rc1, in the process, pinning the versions for launcher, as it doesnt support rc1 at this point.