### PR TITLE
Fix elasticsearch example setup

### DIFF
--- a/collector/elasticsearch/Makefile
+++ b/collector/elasticsearch/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL:=help
 
 # --------------------------
-.PHONY: setup keystore certs all elastic build down stop restart rm logs
+.PHONY: setup keystore certs elastic build down stop restart rm logs
 
 keystore:		## Setup Elasticsearch Keystore, by initializing passwords, and add credentials defined in `keystore.sh`.
 	docker-compose -f docker-compose.setup.yml run --rm keystore
@@ -45,9 +45,6 @@ images:			## Show all Images of ElasticSearch and all its extra components.
 prune:			## Remove ElasticSearch Containers and Delete ElasticSearch-related Volume Data (the Elastic_Elasticsearch-data volume)
 	@make stop && make rm
 	@docker volume prune -f --filter label=com.docker.compose.project=elasticsearch
-
-all:		    ## Start Elk and all its component (ELK, Monitoring, and Tools).
-	docker-compose ${COMPOSE_ALL_FILES} up -d --build ${ELK_MAIN_SERVICES}
 
 up:
 	@if [ ! -d "secrets" ]; then echo "Did not find secrets directory. Starting setup."; \

--- a/collector/elasticsearch/docker-compose.override.yml
+++ b/collector/elasticsearch/docker-compose.override.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.51.0
+    image: otel/opentelemetry-collector-contrib:0.53.0
     environment:
       LS_ACCESS_TOKEN: ${LS_ACCESS_TOKEN}
     configs:

--- a/collector/elasticsearch/docker-compose.setup.yml
+++ b/collector/elasticsearch/docker-compose.setup.yml
@@ -1,12 +1,8 @@
-version: '3.5'
+version: '3.9'
 
 services:
   keystore:
-    image: elastdocker/elasticsearch:${ELASTIC_VERSION}
-    build:
-      context: elasticsearch/
-      args:
-        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
     command: bash /setup/setup-keystore.sh
     user: "0"
     volumes:
@@ -16,11 +12,7 @@ services:
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
 
   certs:
-    image: elastdocker/elasticsearch:${ELASTIC_VERSION}
-    build:
-      context: elasticsearch/
-      args:
-        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
     command: bash /setup/setup-certs.sh
     user: "0"
     volumes:


### PR DESCRIPTION
The setup container used for this example previously depended upon an image which could not be pulled or built from the present state of the directory. Ergo, while it continued to work on the dev machine I overlooked that it would fail elsewhere. This PR is aimed at correcting that by using the official docker base image for elasticsearch instead of the custom overlay which we deleted.