### PR TITLE
Add consul example

### DIFF
--- a/collector/consul/README.md
+++ b/collector/consul/README.md
@@ -1,0 +1,88 @@
+# Ingest Consul metrics using the OpenTelemetry Collector
+
+## Overview
+
+ Consul natively exposes a Prometheus endpoint and the OpenTelemetry Collector has a [Prometheus receiver][otel-prom-receiver] that can be used to scrape its Prometheus endpoint. This directory contains an example showing how to configure Consul and the Collector to send metrics to Lightstep Observability.
+
+ This example is based on the [service mesh][consul-service-mesh-example-repo] example from the [learn Consul repository][learn-consul-repo]. See the [repository][consul-service-mesh-example-repo], or this [Consul service mesh tutorial][consul-service-mesh-example-docs] for more about the underlying Consul setup in the example.
+
+## Prerequisites
+
+* Docker
+* Docker Compose
+* A Lightstep Observability [access token][ls-docs-access-token]
+
+## How to run the example
+
+* Export your Lightstep access token
+  ```
+  export LS_ACCESS_TOKEN=<YOUR_TOKEN>
+  ```
+* Run the docker compose example
+  ```
+  docker-compose up -d
+  ```
+* Install services
+  ```
+  chmod 755 service-install.sh
+  ./service-install.sh
+  ```
+* Explore the example
+* Clean up
+  ```
+  docker-compose down --rmi all`
+  ```
+
+### Explore Metrics in Lightstep
+
+See the [Consul Telemetry Docs][consul-docs-telemetry] for comprehensive documentation on metrics emitted. Note that the the metrics collected via prometheus will be renamed to conform to prometheus conventions; dots will be replaced with underscores (e.g. consul.kvs.apply will be renamed to consul_kvs_apply). Consul metrics will be prefixed with "consul_" and you can build dashboards with them in Lightstep Observability. See the [dashboard documentation][ls-docs-dashboards] for more details.
+
+### Explore the Consul Example
+
+* The Consul UI is available at [http://localhost:8500/ui](http://localhost:8500/ui/).
+* See the Counting Service at [http://localhost:9002](http://localhost:9002)
+* Inspect the Prometheus endpoint at [http://localhost:8500/v1/agent/metrics?format=prometheus](http://localhost:8500/v1/agent/metrics?format=prometheus)
+
+
+## Configure Consul
+
+Consul has native support for Prometheus, but you need to set the `prometheus_retention_time` configuration option to a number greater than zero for it to be enabled. The documentation also recommends setting `disable_hostname` to `true` to prevent metrics from being prefixed with hostname. See the Consul Server configuration example below in HCL format. Adapt as needed for other formats (json, yaml, etc).
+
+```hcl
+telemetry {
+  prometheus_retention_time = "60s"
+  disable_hostname = true
+}
+```
+
+## Configure the Collector
+
+Below is a snippet showing how to configure the Prometheus Receiver to scrape the Prometheus endpoint exposed by the Consul Server.
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'consul-server'
+          metrics_path: '/v1/agent/metrics'
+          params:
+            format: ['prometheus']
+          static_configs:
+            - targets: ['localhost:8500']
+```
+
+
+
+## Additional information
+
+- [OpenTelemetry Collector Prometheus Receiver][otel-prom-receiver]
+- [Consul Telemetry Reference][consul-docs-telemetry]
+
+[ls-docs-access-token]: https://docs.lightstep.com/docs/create-and-manage-access-tokens
+[ls-docs-dashboards]: https://docs.lightstep.com/docs/create-and-manage-dashboards
+[otel-prom-receiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
+[consul-docs-telemetry]: https://www.consul.io/docs/agent/telemetry#key-metrics
+[consul-service-mesh-example-docs]: https://learn.hashicorp.com/tutorials/consul/service-mesh-with-envoy-proxy
+[consul-service-mesh-example-repo]: https://github.com/hashicorp/learn-consul-docker/tree/main/datacenter-deploy-service-mesh/config-entries
+[learn-consul-repo]: https://github.com/hashicorp/learn-consul-docker

--- a/collector/consul/client1.json
+++ b/collector/consul/client1.json
@@ -1,0 +1,26 @@
+{
+  "node_name": "consul-client1",
+  "datacenter": "dc1",
+  "data_dir": "/consul/data",
+  "log_level":"INFO",
+  "retry_join":[
+      "consul-server"
+   ],
+  "service": {
+    "name": "counting",
+    "port": 9003,
+    "connect": {
+      "sidecar_service": {}
+    },
+    "check": {
+      "id": "counting-check",
+      "http": "http://localhost:9003/health",
+      "method": "GET",
+      "interval": "1s",
+      "timeout": "1s"
+    }
+  },
+  "ports": {
+    "grpc": 8502
+    }
+}

--- a/collector/consul/client2.json
+++ b/collector/consul/client2.json
@@ -1,0 +1,35 @@
+{
+  "node_name": "consul-client2",
+  "datacenter": "dc1",
+  "data_dir": "/consul/data",
+  "log_level":"INFO",
+  "retry_join":[
+      "consul-server"
+   ],
+  "service": {
+    "name": "dashboard",
+    "port": 9002,
+    "connect": {
+      "sidecar_service": {
+        "proxy": {
+          "upstreams": [
+            {
+              "destination_name": "counting",
+              "local_bind_port": 5000
+            }
+          ]
+        }
+      }
+    },
+    "check": {
+      "id": "dashboard-check",
+      "http": "http://localhost:9002/health",
+      "method": "GET",
+      "interval": "1s",
+      "timeout": "1s"
+    }
+  },
+  "ports": {
+    "grpc": 8502
+    }
+}

--- a/collector/consul/collector.yml
+++ b/collector/consul/collector.yml
@@ -1,0 +1,29 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'consul-server'
+          scrape_interval: 10s
+          metrics_path: '/v1/agent/metrics'
+          params:
+            format: ['prometheus']
+          static_configs:
+            - targets: ['consul-server:8500']
+
+exporters:
+  logging:
+    loglevel: debug
+  otlp:
+    endpoint: ingest.lightstep.com:443
+    headers:
+      "lightstep-access-token": "${LS_ACCESS_TOKEN}"
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [logging, otlp]

--- a/collector/consul/docker-compose.yml
+++ b/collector/consul/docker-compose.yml
@@ -1,0 +1,65 @@
+version: '3.7'
+
+services:
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.51.0
+    command: ["--config=/conf/collector.yml"]
+    ports:
+      - 8888:8888
+    environment:
+      LS_ACCESS_TOKEN: ${LS_ACCESS_TOKEN}
+    volumes:
+      - ./collector.yml:/conf/collector.yml:ro
+    networks:
+      - consul
+    depends_on:
+      - consul-server
+
+  consul-server:
+    image: hashicorp/consul:1.12.2
+    container_name: consul-server
+    restart: always
+    volumes:
+     - ./server.json:/consul/config/server.json:ro
+    networks:
+      - consul
+    ports:
+      - "8500:8500"
+      - "8600:8600/tcp"
+      - "8600:8600/udp"
+    command: "agent"
+
+  consul-client1:
+    image: hashicorp/consul:1.12.2
+    container_name: consul-client1
+    restart: always
+    volumes:
+     - ./client1.json:/consul/config/client1.json:ro
+     - ./intention-config-entry.json:/intention-config-entry.json
+    networks:
+      - consul
+    ports:
+      - "9003:9003"
+    environment:
+      - PORT=9003
+    command: "agent"
+
+  consul-client2:
+    image: hashicorp/consul:1.12.2
+    container_name: consul-client2
+    restart: always
+    volumes:
+     - ./client2.json:/consul/config/client2.json:ro
+    networks:
+      - consul
+    ports:
+      - "9002:9002"
+    environment:
+      - PORT=9002
+      - COUNTING_SERVICE_URL=http://localhost:5000
+    command: "agent"
+
+networks:
+  consul:
+    driver: bridge

--- a/collector/consul/intention-config-entry.json
+++ b/collector/consul/intention-config-entry.json
@@ -1,0 +1,10 @@
+{
+    "Kind": "service-intentions",
+    "Name": "counting",
+    "Sources": [
+      {
+        "Name": "dashboard",
+        "Action": "allow"
+      }
+    ]
+}

--- a/collector/consul/server.json
+++ b/collector/consul/server.json
@@ -1,0 +1,21 @@
+{
+    "node_name": "consul-server",
+    "server": true,
+    "bootstrap" : true,
+    "ui_config": {
+        "enabled" : true
+    },
+    "datacenter": "dc1",
+    "data_dir": "/consul/data",
+    "telemetry": {
+        "prometheus_retention_time": "60s",
+        "disable_hostname": true
+    },
+    "log_level":"INFO",
+    "addresses": {
+        "http" : "0.0.0.0"
+    },
+      "connect": {
+         "enabled": true
+        }
+}

--- a/collector/consul/service-install.sh
+++ b/collector/consul/service-install.sh
@@ -1,0 +1,37 @@
+###
+# Container 1
+###
+
+# Download sample data layer service, Counting service
+docker exec -d consul-client1 wget https://github.com/hashicorp/demo-consul-101/releases/download/0.0.3.1/counting-service_linux_amd64.zip
+sleep 7s
+# Unzip Counting service
+docker exec -d consul-client1 unzip counting-service_linux_amd64.zip
+sleep 7s
+# Start Counting service as background process in container
+docker exec -d consul-client1 ./counting-service_linux_amd64 &
+sleep 1s
+# Start Consul Sidecar Proxy for Counting service
+docker exec -d consul-client1 consul connect proxy -sidecar-for counting &
+sleep 1s
+
+###
+# Container 2
+###
+
+# Download sample data layer service, Dashboard service
+docker exec -d consul-client2 wget https://github.com/hashicorp/demo-consul-101/releases/download/0.0.3.1/dashboard-service_linux_amd64.zip
+sleep 7s
+# Unzip Counting service
+docker exec -d consul-client2 unzip dashboard-service_linux_amd64.zip
+sleep 7s
+# Start Dashboard service as background process in container
+docker exec -d consul-client2 ./dashboard-service_linux_amd64 &
+sleep 1s
+# Start Consul Sidecar Proxy for Dashboard service
+docker exec -d consul-client2 consul connect proxy -sidecar-for dashboard &
+sleep 1s
+
+# Create Consul intention with Dashboard as source and Counting as destination
+docker exec -d consul-client1 consul config write intention-config-entry.json
+sleep 1s


### PR DESCRIPTION
This PR adds an example demonstrating how to use the OTel Collector Prometheus Receiver to scrape metrics from Hashicorp Consul. 