### PR TITLE
Update update-containers.yml

### DIFF
--- a/.github/workflows/update-containers.yml
+++ b/.github/workflows/update-containers.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         component: [
           'go-opentracing-server', 'go-opentracing-client',
-          'go-opentelemetry-server', 'go-opentelemetry-client',
+          'go-opentelemetry-collector-server', 'go-opentelemetry-collector-client',
+          'go-opentelemetry-otlp-server', 'go-opentelemetry-otlp-client',
           'go-launcher-server', 'go-launcher-client',
           'py-collector-client', 'py-collector-server',
           'py-opentelemetry-client', 'py-opentelemetry-server',


### PR DESCRIPTION
@codeboten I noticed that one of the GH actions was failing post-merge of #106, and I think it may be related to this file referencing the old go service names.