### PR TITLE
Add OpenTelemetry tracing to Envoy example

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,10 @@
 name: Run integration test
 
 on:
-  pull_request:  
+  pull_request:
+    # collector-based examples have their own Dockerfiles/docker-compose.ymls
+    paths-ignore:
+      - 'collector/**'
 
 env:
   DOCKER_BUILDKIT: 1

--- a/collector/envoy/Dockerfile-frontenvoy
+++ b/collector/envoy/Dockerfile-frontenvoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy-dev:4e2c7adfb393a8ea2a38c94494ccd2ee0fd469f9
+FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y curl \

--- a/collector/envoy/Dockerfile-frontenvoy
+++ b/collector/envoy/Dockerfile-frontenvoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy-dev:latest
+FROM envoyproxy/envoy-dev:4e2c7adfb393a8ea2a38c94494ccd2ee0fd469f9
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y curl \

--- a/collector/envoy/README.md
+++ b/collector/envoy/README.md
@@ -1,10 +1,11 @@
 # Ingest Envoy metrics using OTEL Collector's Prometheus receiver
 
-This example illustrates how you can ingest Envoy metrics using the OTEL collector's Prometheus receiver. Envoy exposes a Prometheus compatible metrics endpoint.
+This example illustrates how you can ingest Envoy metrics and traces. Envoy exposes a Prometheus compatible metrics endpoint and has built-in (experimental as of v1.23.0) support for generating OpenTelemetry traces.
 
 ## Requirements
 
 * OpenTelemetry Collector Contrib v0.51.0+
+* Envoy v1.23.0+
 
 ## Prerequisites
 
@@ -14,11 +15,20 @@ You must have a Lightstep Observability [access token](/docs/create-and-manage-a
 
 You can run this example with `docker-compose up` in this directory. Using `docker-compose --profile loadgen up` also creates an instance to send requests to the NGINX service. You'll want to view this in Lightstep with a dashboard. 
 
-## Configuration
+```
+  $ export LS_ACCESS_TOKEN=<your-lightstep-access-token>
+  $ docker-compose up
+
+  # make some requests
+  $ curl http://localhost:8080/service/1
+  $ curl http://localhost:8080/service/2
+```
+
+## Configuration: Metrics
 
 Installation of the OpenTelemetry Collector varies, please refer to the [collector documentation](https://opentelemetry.io/docs/collector/) for more information.
 
-The example configuration used for this project shows how to configure OTEL's prometheus receiver to collect metrics from an Envoy endpoint. Note that Envoy provides metrics at a custom path of `/stats/prometheus` instead of the usual `/metrics` endpoint.
+The example configuration used for this project shows how to configure the collector's prometheus receiver to collect metrics from an Envoy endpoint. Note that Envoy provides metrics at a custom path of `/stats/prometheus` instead of the usual `/metrics` endpoint.
 
 ``` yaml
 receivers:
@@ -55,6 +65,11 @@ service:
 
 ```
 
+## Configuration: Traces
+
+This example forwards traces from Envoy to a locally-running collector using gRPC. See `service-envoy.yaml` for configuration details.
+
 ## Additional resources
 
-* This example is based on [EnvoyProxy's front-proxy sandbox](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/front_proxy). See [EnvoyProxy's sandboxes](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/) for alternative examples.
+* Envoy v1.23.0 [OpenTelemetry tracer](https://www.envoyproxy.io/docs/envoy/v1.23.0/api-v3/config/trace/v3/opentelemetry.proto.html?highlight=opentelemetry) docs.
+* This example is based on [Envoy's front-proxy sandbox](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/front_proxy). See [Envoy's sandboxes](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/) for alternative examples.

--- a/collector/envoy/app/tracing/Dockerfile
+++ b/collector/envoy/app/tracing/Dockerfile
@@ -1,7 +1,7 @@
 FROM flask_service:python-3.10-slim-bullseye
 
 # envoy v1.23.0
-COPY --from=envoyproxy/envoy-dev:4e2c7adfb393a8ea2a38c94494ccd2ee0fd469f9 /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=envoyproxy/envoy-dev:latest /usr/local/bin/envoy /usr/local/bin/envoy
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt

--- a/collector/envoy/app/tracing/Dockerfile
+++ b/collector/envoy/app/tracing/Dockerfile
@@ -1,6 +1,7 @@
 FROM flask_service:python-3.10-slim-bullseye
 
-COPY --from=envoyproxy/envoy-dev:latest /usr/local/bin/envoy /usr/local/bin/envoy
+# envoy v1.23.0
+COPY --from=envoyproxy/envoy-dev:4e2c7adfb393a8ea2a38c94494ccd2ee0fd469f9 /usr/local/bin/envoy /usr/local/bin/envoy
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt

--- a/collector/envoy/app/tracing/service.py
+++ b/collector/envoy/app/tracing/service.py
@@ -21,6 +21,10 @@ TRACE_HEADERS_TO_PROPAGATE = [
     # Jaeger header (for native client)
     "uber-trace-id",
 
+    # w3c headers
+    "traceparent",
+    "tracestate",
+
     # SkyWalking headers.
     "sw8"
 ]
@@ -29,10 +33,12 @@ TRACE_HEADERS_TO_PROPAGATE = [
 @app.route('/service/<service_number>')
 def hello(service_number):
     return (
-        'Hello from behind Envoy (service {})! hostname: {} resolved'
+        'Hello from behind Envoy (service {})! hostname: {} resolved, traceparent: {}\n'
         'hostname: {}\n'.format(
             os.environ['SERVICE_NAME'], socket.gethostname(),
-            socket.gethostbyname(socket.gethostname())))
+            request.headers['traceparent'],
+            socket.gethostbyname(socket.gethostname()),
+            ))
 
 
 @app.route('/trace/<service_number>')

--- a/collector/envoy/collector.yml
+++ b/collector/envoy/collector.yml
@@ -25,6 +25,9 @@ processors:
 
 service:
   pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging, otlp/public]
     metrics:
       receivers: [otlp, prometheus/front-proxy]
       processors: [batch]

--- a/collector/envoy/docker-compose.override.yaml
+++ b/collector/envoy/docker-compose.override.yaml
@@ -15,7 +15,7 @@ services:
   loadgen:
     depends_on: [nginx_proxy]
     image: williamyeh/hey
-    command: ["-z", "10m", "-c", "50", "-q", "50", "http://front-envoy:8080"]
+    command: ["-z", "10m", "-c", "50", "-q", "50", "http://localhost:8080/service/1"]
     # to keep this from starting under regular invocation
     profiles:
       - loadgen

--- a/collector/envoy/docker-compose.override.yaml
+++ b/collector/envoy/docker-compose.override.yaml
@@ -15,7 +15,7 @@ services:
   loadgen:
     depends_on: [nginx_proxy]
     image: williamyeh/hey
-    command: ["-z", "10m", "-c", "50", "-q", "50", "http://localhost:8080/service/1"]
+    command: ["-z", "10m", "-c", "50", "-q", "50", "http://front-envoy:8080/service/1"]
     # to keep this from starting under regular invocation
     profiles:
       - loadgen

--- a/collector/envoy/docker-compose.yaml
+++ b/collector/envoy/docker-compose.yaml
@@ -10,14 +10,6 @@ services:
     deploy:
       replicas: 0
 
-  tracing:
-    build:
-      context: ./app/tracing
-    image: envoyproxy:tracing
-    restart: "no"
-    deploy:
-      replicas: 0
-
   # front-proxy
   front-envoy:
     build:
@@ -27,16 +19,18 @@ services:
     - "8080:8080"
     - "8443:8443"
     - "8001:8001"
-
+    
   service1:
-    image: envoyproxy:tracing
+    build:
+      context: ./app/tracing
     volumes:
     - ./service-envoy.yaml:/etc/service-envoy.yaml
     environment:
     - SERVICE_NAME=1
 
   service2:
-    image: envoyproxy:tracing
+    build:
+      context: ./app/tracing
     volumes:
     - ./service-envoy.yaml:/etc/service-envoy.yaml
     environment:

--- a/collector/envoy/front-envoy.yaml
+++ b/collector/envoy/front-envoy.yaml
@@ -1,3 +1,5 @@
+# see: https://github.com/envoyproxy/envoy/tree/v1.23.0/examples/front-proxy
+
 static_resources:
   listeners:
   - address:
@@ -11,6 +13,20 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: AUTO
           stat_prefix: ingress_http
+          tracing:
+            verbose: true
+            provider:
+              # Envoy v1.23.0 and later OpenTelemetry-based tracing configuration
+              name: envoy.tracers.opentelemetry
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: local_collector
+                  initial_metadata:
+                    - key: lightstep-access-token
+                      value: "set-in-collector"
+                service_name: front-envoy
           route_config:
             name: local_route
             virtual_hosts:
@@ -42,6 +58,20 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: AUTO
           stat_prefix: ingress_http
+          tracing:
+            verbose: true
+            provider:
+              # Envoy v1.23.0 and later OpenTelemetry-based tracing configuration
+              name: envoy.tracers.opentelemetry
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: local_collector
+                  initial_metadata:
+                    - key: lightstep-access-token
+                      value: "set-in-collector"
+                service_name: front-envoy
           route_config:
             name: local_route
             virtual_hosts:
@@ -151,6 +181,24 @@ static_resources:
               socket_address:
                 address: service2
                 port_value: 8000
+  - name: local_collector
+    connect_timeout: 40s
+    type: strict_dns
+    lb_policy: least_request
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {} # enable H2 protocol
+    load_assignment:
+      cluster_name: local_collector
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: otel-collector
+                  port_value: 4317
 admin:
   address:
     socket_address:

--- a/collector/envoy/service-envoy.yaml
+++ b/collector/envoy/service-envoy.yaml
@@ -1,3 +1,5 @@
+# see: https://github.com/envoyproxy/envoy/tree/v1.23.0/examples/front-proxy
+
 static_resources:
   listeners:
   - address:
@@ -11,6 +13,20 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: AUTO
           stat_prefix: ingress_http
+          tracing:
+            verbose: true
+            provider:
+              # Envoy v1.23.0 and later OpenTelemetry-based tracing configuration
+              name: envoy.tracers.opentelemetry
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: local_collector
+                  initial_metadata:
+                    - key: lightstep-access-token
+                      value: "set-in-collector"
+                service_name: service-envoy
           route_config:
             name: local_route
             virtual_hosts:
@@ -39,6 +55,24 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 8080
+  - name: local_collector
+    connect_timeout: 40s
+    type: strict_dns
+    lb_policy: least_request
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {} # enable H2 protocol
+    load_assignment:
+      cluster_name: local_collector
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: otel-collector
+                  port_value: 4317
 admin:
   address:
     socket_address:

--- a/go/launcher/client/Dockerfile
+++ b/go/launcher/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.18-alpine
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go/launcher/server/Dockerfile
+++ b/go/launcher/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.18-alpine
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Updates Envoy example to show how to use the (new) OpenTelemetry-based tracer in Envoy with a basic collector.

![image](https://user-images.githubusercontent.com/27153/182697466-ac13d4de-fd71-4dad-bd85-7cf1e9cd3125.png)
