### PR TITLE
[collector/httpcheck] adding example for http check receiver

### DIFF
--- a/collector/httpcheck/README.md
+++ b/collector/httpcheck/README.md
@@ -1,0 +1,32 @@
+# Run synthethic checks OTel Collector's HTTP Check receiver
+
+The OpenTelemetry Collector [HTTP Check receiver](httpcheckreceiver) connects to a configured endpoint via HTTP to validate that the endpoint is responding with a status code 200. The examples in this repo show how to configure an HTTP endpoint and the Collector to send metrics to Lightstep Observability.
+
+## Requirements
+
+* OpenTelemetry Collector Contrib v0.61.0+
+* Docker Compose
+
+## Prerequisites
+
+You must have a Lightstep Observability [access token][ls-docs-access-token] for the project to report metrics to.
+
+## Running the Example
+
+**Set LS_ACCESS_TOKEN as an environment variable**
+
+The `docker-compose.yml` assumes your access token has been set as an environment variable named `LS_ACCESS_TOKEN`. Set the environment variable using the method of your choosing, for example:
+
+```
+export LS_ACCESS_TOKEN=<YOUR-TOKEN>
+```
+
+Run Docker compose
+
+```
+docker-compose up
+```
+
+[httpcheckreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver
+[ls-docs-access-token]: https://docs.lightstep.com/docs/create-and-manage-access-tokens
+[ls-docs-dashboards]: https://docs.lightstep.com/docs/create-and-manage-dashboards

--- a/collector/httpcheck/collector.yml
+++ b/collector/httpcheck/collector.yml
@@ -1,0 +1,22 @@
+exporters:
+    logging:
+        loglevel: debug
+    otlp/lightstep:
+      endpoint: ingest.lightstep.com:443
+      headers:
+        "lightstep-access-token": "${LS_ACCESS_TOKEN}"
+
+processors:
+    batch:
+
+receivers:
+  httpcheck/webserver:
+    endpoint: http://webserver
+    collection_interval: 5s
+
+service:
+  pipelines:
+    metrics:
+      receivers: [httpcheck/webserver]
+      processors: [batch]
+      exporters: [logging, otlp/lightstep]

--- a/collector/httpcheck/docker-compose.yml
+++ b/collector/httpcheck/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+    webserver:
+        container_name: webserver
+        image: nginx
+        ports:
+            - '8080:80'
+        networks:
+            - integrations
+        stop_grace_period: 1s
+    otel-collector:
+        container_name: otel-collector
+        image: otel/opentelemetry-collector-contrib:0.61.0
+        command: ["--config=/conf/collector.yml"]
+        environment:
+            LS_ACCESS_TOKEN: ${LS_ACCESS_TOKEN}
+        networks:
+            - integrations
+        volumes:
+            - ./collector.yml:/conf/collector.yml:r
+networks:
+    integrations:


### PR DESCRIPTION
This example uses a local nginx server as an endpoint for the HTTP check receiver, which produces a duration and success metric.