### PR TITLE
Add sshcheck receiver example

### DIFF
--- a/collector/sshcheck/Dockerfile
+++ b/collector/sshcheck/Dockerfile
@@ -1,0 +1,26 @@
+##########################################
+FROM golang:1.18-alpine as builder
+
+ARG REPO
+ARG BRANCH
+ENV REPO_URL=https://github.com/${REPO}
+ENV REPO_PATH=/go/src/github.com/${REPO}
+ENV REPO_BRANCH=${BRANCH}
+
+RUN mkdir -p ${REPO_PATH}
+RUN apk add --no-cache git
+
+RUN git clone -b ${REPO_BRANCH} --single-branch --depth 1 ${REPO_URL} ${REPO_PATH}
+
+WORKDIR ${REPO_PATH}
+RUN go mod tidy
+# must pass flags for static or will not work on scratch
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s' -ldflags '-extldflags "-lm -stdc++ -static"' -o /otelcontribcol ./cmd/otelcontribcol
+
+FROM scratch 
+# copy ca certs
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# copy bin
+COPY --from=builder /otelcontribcol /otelcontribcol
+
+COPY collector.yml /collector.yml

--- a/collector/sshcheck/README.md
+++ b/collector/sshcheck/README.md
@@ -1,0 +1,32 @@
+# Run synthethic checks OTel Collector's SSH Check receiver
+
+The OpenTelemetry Collector [SSH Check receiver](sshcheckreceiver) connects to a configured endpoint via SSH to validate that the client can connect. The examples in this repo show how to configure an SSH endpoint and the Collector to send metrics to Lightstep Observability.
+
+## Requirements
+
+* OpenTelemetry Collector Contrib v0.61.0+
+* Docker Compose
+
+## Prerequisites
+
+You must have a Lightstep Observability [access token][ls-docs-access-token] for the project to report metrics to.
+
+## Running the Example
+
+**Set LS_ACCESS_TOKEN as an environment variable**
+
+The `docker-compose.yml` assumes your access token has been set as an environment variable named `LS_ACCESS_TOKEN`. Set the environment variable using the method of your choosing, for example:
+
+```
+export LS_ACCESS_TOKEN=<YOUR-TOKEN>
+```
+
+Run Docker compose
+
+```
+docker-compose up
+```
+
+[sshcheckreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sshcheckreceiver
+[ls-docs-access-token]: https://docs.lightstep.com/docs/create-and-manage-access-tokens
+[ls-docs-dashboards]: https://docs.lightstep.com/docs/create-and-manage-dashboards

--- a/collector/sshcheck/collector.yml
+++ b/collector/sshcheck/collector.yml
@@ -1,0 +1,29 @@
+exporters:
+    logging:
+        loglevel: debug
+    otlp/lightstep:
+      endpoint: ingest.lightstep.com:443
+      headers:
+        "lightstep-access-token": "${LS_ACCESS_TOKEN}"
+
+processors:
+    batch:
+
+receivers:
+  sshcheck/sshserver:
+    endpoint: sshserver:2222 
+    username: otelu
+    password: otelp
+    collection_interval: 25s
+    metrics:
+      sshcheck.sftp_success:
+        enabled: true
+      sshcheck.sftp_duration:
+        enabled: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [sshcheck/sshserver]
+      processors: [batch]
+      exporters: [logging, otlp/lightstep]

--- a/collector/sshcheck/docker-compose.yml
+++ b/collector/sshcheck/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.9'
+services:
+    ssh-server:
+        container_name: sshserver
+        image: lscr.io/linuxserver/openssh-server
+        ports:
+            - '2222:2222'
+        networks:
+            - integrations
+        stop_grace_period: 1s
+
+    otel-collector:
+        build:
+          context: .
+          args:
+            - REPO=nslaughter/opentelemetry-collector-contrib
+            - BRANCH=pr-sshreceiver
+        command: ["./otelcontribcol", "--config=/conf/collector.yml"]
+        environment:
+            LS_ACCESS_TOKEN: ${LS_ACCESS_TOKEN}
+        networks:
+            - integrations
+        volumes:
+            - ./collector.yml:/conf/collector.yml:r
+
+networks:
+    integrations:


### PR DESCRIPTION
This is presently the example which runs the Collector code in development with the new sshcheck receiver. Before merging we will update this to work like other examples using the image of the latest OTel build.

At this point I expect that the way the receiver works could change in a way that will require the collector config to change.