### PR TITLE
add OTel JS vanilla tracing example

### DIFF
--- a/nodejs/otel-vanilla/tracing/app.js
+++ b/nodejs/otel-vanilla/tracing/app.js
@@ -1,0 +1,31 @@
+'use strict';
+const opentelemetry = require('@opentelemetry/api');
+const tracer = opentelemetry.trace.getTracer('otel-js-demo');
+let count = 0;
+
+setInterval(() => {
+  // start a trace by starting a new span
+  tracer.startActiveSpan('parent', (parent) => {
+    // set an attribute
+    parent.setAttribute('count', count);
+    // record an event
+    parent.addEvent(`message: ${count}`);
+
+    // create a child span
+    const child1 = tracer.startSpan('child-1');
+    child1.end();
+
+    // create a second child span
+    const child2 = tracer.startSpan('child-2');
+    // record an error status on a span
+    const err = new Error('there was a problem');
+    child2.setStatus({code: opentelemetry.SpanStatusCode.ERROR, message: err.message});
+    // record the err as an exception (event) on the span
+    child2.recordException(err);
+    child2.end();
+
+    // end the trace
+    parent.end();
+    count++;
+  });
+}, 10000);

--- a/nodejs/otel-vanilla/tracing/index.js
+++ b/nodejs/otel-vanilla/tracing/index.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { NodeSDK } = require('@opentelemetry/sdk-node');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto');
+const { Resource } = require('@opentelemetry/resources');
+const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
+const { diag, DiagLogLevel, DiagConsoleLogger} = require('@opentelemetry/api');
+
+const token = process.env.LS_ACCESS_TOKEN;
+const exportUrl =
+  process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
+  'https://ingest.lightstep.com/traces/otlp/v0.9';
+const serviceName = process.env.LS_SERVICE_NAME || 'otel-js-demo';
+
+const collectorOptions = {
+  url: exportUrl,
+  headers: { 'Lightstep-Access-Token': token },
+};
+
+const traceExporter = new OTLPTraceExporter(collectorOptions);
+
+const sdk = new NodeSDK({
+  resource: new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: 'otel-js-demo',
+  }),
+  traceExporter,
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)
+
+sdk.start().then(
+    require('./app')
+);

--- a/nodejs/otel-vanilla/tracing/package.json
+++ b/nodejs/otel-vanilla/tracing/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tracing",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@opentelemetry/api": "^1.2.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.33.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0",
+    "@opentelemetry/resources": "^1.7.0",
+    "@opentelemetry/sdk-node": "^0.33.0",
+    "@opentelemetry/semantic-conventions": "^1.7.0"
+  }
+}


### PR DESCRIPTION
This PR adds a OTel JS vanilla tracing example. The SDK setup is in `index.js` and the tracing example is in `app.js`.