### PR TITLE
update vanilla js metrics with ga deps

### DIFF
--- a/nodejs/otel-vanilla/metrics/app.js
+++ b/nodejs/otel-vanilla/metrics/app.js
@@ -2,7 +2,7 @@ const opentelemetry = require('@opentelemetry/api');
 const {
   MeterProvider,
   PeriodicExportingMetricReader,
-} = require('@opentelemetry/sdk-metrics-base');
+} = require('@opentelemetry/sdk-metrics');
 const {
   OTLPMetricExporter,
 } = require('@opentelemetry/exporter-metrics-otlp-proto');

--- a/nodejs/otel-vanilla/metrics/package.json
+++ b/nodejs/otel-vanilla/metrics/package.json
@@ -11,10 +11,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@opentelemetry/api": "^1.1.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.31.0",
-    "@opentelemetry/resources": "^1.5.0",
-    "@opentelemetry/sdk-metrics-base": "^0.31.0",
-    "@opentelemetry/semantic-conventions": "^1.5.0"
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
+    "@opentelemetry/resources": "^1.8.0",
+    "@opentelemetry/sdk-metrics": "^1.8.0",
+    "@opentelemetry/semantic-conventions": "^1.8.0"
   }
 }


### PR DESCRIPTION
This PR updates the OTel vanilla JS metrics example with the GA metrics dependencies.