### PR TITLE
Add example of turning logs into metrics (draft)

### DIFF
--- a/collector/nginx/collector.yml
+++ b/collector/nginx/collector.yml
@@ -1,39 +1,65 @@
 receivers:
+  filelog:
+    include:
+      - /var/log/nginx/proxy-access.log
+    start_at: beginning
   nginx/proxy:
-    endpoint: 'http://nginx_proxy:8080/status'
+    endpoint: http://nginx_proxy:8080/status
     collection_interval: 10s
   nginx/appsrv:
-    endpoint: 'http://nginx_appsrv:1080/status'
+    endpoint: http://nginx_appsrv:1080/status
     collection_interval: 10s
-
 exporters:
   logging:
     loglevel: debug
   otlp/public:
     endpoint: ingest.lightstep.com:443
     headers:
-        "lightstep-access-token": "${LS_ACCESS_TOKEN}"
-
+      lightstep-access-token: ${LS_ACCESS_TOKEN}
 processors:
   resource/proxy:
     attributes:
-    - key: instance.type
-      value: "proxy"
-      action: insert
+      - key: instance.type
+        value: proxy
+        action: insert
   resource/appsrv:
     attributes:
-    - key: instance.type
-      value: "appsrv"
-      action: insert
+      - key: instance.type
+        value: appsrv
+        action: insert
   batch:
+connectors:
+  count:
+
 
 service:
   pipelines:
+    # Log to metrics pipeline using connector
+    logs/proxy:
+      receivers:
+        - filelog
+      exporters:
+        - count
+    # Count incoming telemetry types, then log and send to public
+    metrics/count:
+      receivers:
+        - count
+      exporters:
+        - logging
+        - otlp/public
     metrics/proxy:
-      receivers: [nginx/proxy]
-      processors: [resource/proxy]
-      exporters: [logging, otlp/public]
+      receivers:
+        - nginx/proxy
+      processors:
+        - resource/proxy
+      exporters:
+        - logging
+        - otlp/public
     metrics/appsrv:
-      receivers: [nginx/appsrv]
-      processors: [resource/appsrv]
-      exporters: [logging, otlp/public]
+      receivers:
+        - nginx/appsrv
+      processors:
+        - resource/appsrv
+      exporters:
+        - logging
+        - otlp/public

--- a/collector/nginx/docker-compose.yml
+++ b/collector/nginx/docker-compose.yml
@@ -3,19 +3,23 @@ version: '3.9'
 services:
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:0.51.0
+    image: otel/opentelemetry-collector-contrib:0.73.0
     environment:
       LS_ACCESS_TOKEN: ${LS_ACCESS_TOKEN}
     configs:
       - source: collector_conf
         target: /conf/collector.yml
-    command: ["--config=/conf/collector.yml"]
+    command: "--config=/conf/collector.yml --feature-gates service.connectors"
+    volumes:
+      - nginx-logs:/var/log/nginx:ro
+    depends_on:
+      - nginx_proxy
     networks:
       - integrations
 
 # deploys a standalone for the proxy and adds instances
   nginx_proxy:
-    image: nginx:1.19
+    image: nginx:1.23.3
     configs:
       - source: proxy_conf
         target: /etc/nginx/conf.d/nginx.conf
@@ -32,6 +36,8 @@ services:
         reservations:
           cpus: "0.125"
           memory: 64M
+    volumes:
+      - nginx-logs:/var/log/nginx
     networks:
       - integrations
 
@@ -65,6 +71,9 @@ configs:
     file: ./nginx-proxy.conf
   appsrv_conf:
     file: ./nginx-appsrv.conf
+
+volumes:
+  nginx-logs:     
 
 networks:
   integrations:

--- a/collector/nginx/nginx-proxy.conf
+++ b/collector/nginx/nginx-proxy.conf
@@ -1,6 +1,7 @@
 server {
     listen       8080;
     server_name  nginx_proxy;
+    access_log  /var/log/nginx/proxy-access.log;
 
     # forwards requests
     location / {


### PR DESCRIPTION
What does this PR do?
---------------------
* Uses the new `connector` component to turn a nginx request log into metrics.

<img width="738" alt="image" src="https://user-images.githubusercontent.com/27153/226434080-11a7f6cb-3e20-4204-9a24-6e35c5739744.png">
